### PR TITLE
update cdn link

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   </head>
   <body>
     <canvas id="main-game-canvas"></canvas>
-    <script src="https://unpkg.com/kaboom/dist/kaboom.js"></script>
+    <script src="https://unpkg.com/kaboom@2000.2.10/dist/kaboom.js"></script>
     <script type="module" src="./assets/js/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The link for the CDN we were using in the project has updated to use v3000, which does not support some of the code we used. We need to update the link. 